### PR TITLE
Avoid crashing if the schema can't be retrieved by fink-client

### DIFF
--- a/skyportal_fink_client/skyportal_fink_client.py
+++ b/skyportal_fink_client/skyportal_fink_client.py
@@ -59,9 +59,12 @@ def poll_alerts(maxtimeout: int = 5):
         consumer = AlertConsumer(topics, myconfig)
     try:
         while True:
-
-            # Poll the servers
-            topic, alert, key = consumer.poll(maxtimeout)
+            try:
+                # Poll the servers
+                topic, alert, key = consumer.poll(maxtimeout)
+            except Exception as e:
+                print(f"Error while polling: {e}")
+                continue
             # Analyse output - we just print some values for example
             if topic is not None:
                 if alert is not None:

--- a/tests/test_poll_alerts.py
+++ b/tests/test_poll_alerts.py
@@ -72,7 +72,12 @@ def test_poll_alerts():
                 print("No more alerts to process")
                 break
             # Poll the servers
-            topic, alert, key = consumer.poll(maxtimeout)
+            try:
+                # Poll the servers
+                topic, alert, key = consumer.poll(maxtimeout)
+            except Exception as e:
+                print(f"Error while polling: {e}")
+                continue
             # Analyse output - we just print some values for example
             if topic is not None:
                 if alert is not None:


### PR DESCRIPTION
Currently, when receiving an alert, fink-client gets the right schema (downloads it) from its repo on github. However, in production, I noticed that from time to time, probably random connectivity issues, prevent it from recovering the schme successfully. When that happens, we would expect either a certain number of retries, or at least to skip this alert so the code does not crash and stop pulling future alerts.