### PR TITLE
Choose group to post alerts to

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,9 +1,10 @@
+group_id: test_group
+mytopics:
+- test_stream
 username: testuser
 password: null
 servers: localhost:9093
-mytopics:
-  ["test_stream"]
-group_id: test_group
-testing: true
+skyportal_token: 6bfc9d88-95d5-40a9-8b1b-2bba1e773599
 skyportal_url: http://localhost:5000
-skyportal_token: 1a7141f1-3e6e-483e-badd-efe5fa0e8597
+skyportal_group: Fink
+testing: true

--- a/docs/dev_guide/index.md
+++ b/docs/dev_guide/index.md
@@ -74,6 +74,7 @@ Here, if you are running the client in testing mode, you can set the `testing` f
 #### SkyPortal Credentials
 
 The `skyportal_url` and `skyportal_token` fields are used to connect to the SkyPortal instance. The url is simply the address of the SkyPortal instance, and the token is an api token that you can create and/or find in your SkyPortal's user profile.
+The `skyportal_group` field is the group that you want the alerts to belong to. On SkyPortal, if a user wants to see the data you poll from Fink, he should be in this group.
 
 
 ## Running the Tests

--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -72,3 +72,4 @@ This simple argument is a boolean that indicates whether you want to run the cli
 #### SkyPortal Credentials
 
 The `skyportal_url` and `skyportal_token` fields are used to connect to the SkyPortal instance. The url is simply the address of the SkyPortal instance, and the token is an api token that you can create and/or find in your SkyPortal's user profile.
+The `skyportal_group` field is the group that you want to use to classify the alerts in SkyPortal.

--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -72,4 +72,4 @@ This simple argument is a boolean that indicates whether you want to run the cli
 #### SkyPortal Credentials
 
 The `skyportal_url` and `skyportal_token` fields are used to connect to the SkyPortal instance. The url is simply the address of the SkyPortal instance, and the token is an api token that you can create and/or find in your SkyPortal's user profile.
-The `skyportal_group` field is the group that you want to use to classify the alerts in SkyPortal.
+The `skyportal_group` field is the group that you want the alerts to belong to. On SkyPortal, if a user wants to see the data you poll from Fink, he should be in this group.

--- a/skyportal_fink_client/skyportal_fink_client.py
+++ b/skyportal_fink_client/skyportal_fink_client.py
@@ -43,8 +43,8 @@ def poll_alerts(maxtimeout: int = 5):
     topics = list(conf["mytopics"])
     print(f"Fink topics you subscribed to: {topics}")
 
-    fink_id, stream_id, filter_id = skyportal_api.init_skyportal(
-        conf["skyportal_url"], conf["skyportal_token"]
+    group_id, stream_id, filter_id = skyportal_api.init_skyportal(
+        conf["skyportal_group"], conf["skyportal_url"], conf["skyportal_token"]
     )
 
     # Instantiate a consumer, with a given schema if we are testing with fake alerts
@@ -98,7 +98,7 @@ def poll_alerts(maxtimeout: int = 5):
                         magsys,
                         ra,
                         dec,
-                        fink_id,
+                        group_id,
                         filter_id,
                         stream_id,
                         url=conf["skyportal_url"],

--- a/skyportal_fink_client/utils/skyportal_api.py
+++ b/skyportal_fink_client/utils/skyportal_api.py
@@ -597,7 +597,7 @@ def post_stream_access_to_group(stream_id, group_id, url: str, token: str):
     data = {"stream_id": stream_id}
 
     response = api("POST", f"{url}/api/groups/{group_id}/streams", data, token=token)
-    return (response.status_code,)
+    return response.status_code
 
 
 def post_filters(name: str, stream_id: int, group_id: int, url: str, token: str):

--- a/tests/test_poll_alerts.py
+++ b/tests/test_poll_alerts.py
@@ -46,11 +46,11 @@ def test_poll_alerts():
     print(f"Fink topics you subscribed to: {topics}")
     print("adding alerts")
 
-    fink_id, stream_id, filter_id = skyportal_api.init_skyportal(
-        conf["skyportal_url"], conf["skyportal_token"]
+    group_id, stream_id, filter_id = skyportal_api.init_skyportal(
+        conf["skyportal_group"], conf["skyportal_url"], conf["skyportal_token"]
     )
 
-    assert fink_id is not None
+    assert group_id is not None
     assert stream_id is not None
     assert filter_id is not None
     failed_attempts = 0
@@ -111,7 +111,7 @@ def test_poll_alerts():
                         magsys,
                         ra,
                         dec,
-                        fink_id,
+                        group_id,
                         filter_id,
                         stream_id,
                         url=conf["skyportal_url"],

--- a/tests/test_skyportal_api.py
+++ b/tests/test_skyportal_api.py
@@ -152,6 +152,31 @@ def test_post_streams():
     assert data is not None
 
 
+# def test_post_stream_access_to_group():
+#     # post a group
+#     status, group_id = skyportal_api.post_groups(
+#         "StreamAccessTestGroup",
+#         "http://localhost:5000",
+#         skyportal_token,
+#     )
+#     assert status == 200
+#     assert group_id is not None
+#     status, stream_id = skyportal_api.post_streams(
+#         "StreamTestAccessedByGroup",
+#         "http://localhost:5000",
+#         skyportal_token,
+#     )
+#     assert status == 200
+#     assert stream_id is not None
+#     status = skyportal_api.post_stream_access_to_group(
+#         stream_id,
+#         group_id,
+#         "http://localhost:5000",
+#         skyportal_token,
+#     )
+#     assert status == 200
+
+
 def test_post_filters():
     status, data = skyportal_api.post_filters(
         "FilterTestAPI",
@@ -274,7 +299,9 @@ def test_get_taxonomy_id_including_classification():
 
 
 def test_init_skyportal():
-    result = skyportal_api.init_skyportal("http://localhost:5000", skyportal_token)
+    result = skyportal_api.init_skyportal(
+        "TestInitSkyPortalGroup", "http://localhost:5000", skyportal_token
+    )
     assert result is not None
     assert result[0] is not None
     assert result[1] is not None
@@ -283,7 +310,7 @@ def test_init_skyportal():
 
 def test_from_fink_to_skyportal():
     fink_id, stream_id, filter_id = skyportal_api.init_skyportal(
-        "http://localhost:5000", skyportal_token
+        "fink", "http://localhost:5000", skyportal_token
     )
     result = skyportal_api.from_fink_to_skyportal(
         "kilonova",


### PR DESCRIPTION
This PR adds the possibility to select which group to post alerts to in SkyPortal. The name can be specified in the config.