### PR TITLE
Adding fink taxonomy

### DIFF
--- a/tests/test_poll_alerts.py
+++ b/tests/test_poll_alerts.py
@@ -54,7 +54,6 @@ def test_poll_alerts():
     status, taxonomy_id = skyportal_api.get_fink_taxonomy_id(
         conf["skyportal_url"], conf["skyportal_token"]
     )
-    assert taxonomy_id is not None
     if taxonomy_id is None:
         # post taxonomy
         # load taxonomy from data/taxonomy.yaml
@@ -76,6 +75,7 @@ def test_poll_alerts():
             print("Error while posting taxonomy")
             return
         print(f"Fink Taxonomy posted with id {taxonomy_id}")
+        assert taxonomy_id is not None
 
     failed_attempts = 0
     maxtimeout = 5


### PR DESCRIPTION
Rather than recursively trying our best to find a matching classification in skyportal, we now add a custom Fink taxonomy to classify fink alerts.