### PR TITLE
Adding whitelisted argument in config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,7 +4,8 @@ mytopics:
 username: testuser
 password: null
 servers: localhost:9093
-skyportal_token: 6bfc9d88-95d5-40a9-8b1b-2bba1e773599
+skyportal_token: d47f6fb0-5b11-43fa-a725-7dbec3b8bd6b
 skyportal_url: http://localhost:5000
 skyportal_group: Fink
 testing: true
+whitelisted: false

--- a/docs/dev_guide/index.md
+++ b/docs/dev_guide/index.md
@@ -45,9 +45,11 @@ group_id: 'your_fink_group'
 servers: localhost:9093
 mytopics:
   ["test_stream"]
-testing: false
 skyportal_url: http://localhost:5000
 skyportal_token: 9d2530a0-a3dc-446b-9cf9-968736699e5a
+skyportal_group: 'group_name'
+testing: true
+whitelisted: false
 ```
 
 #### Fink credentials
@@ -75,6 +77,7 @@ Here, if you are running the client in testing mode, you can set the `testing` f
 
 The `skyportal_url` and `skyportal_token` fields are used to connect to the SkyPortal instance. The url is simply the address of the SkyPortal instance, and the token is an api token that you can create and/or find in your SkyPortal's user profile.
 The `skyportal_group` field is the group that you want the alerts to belong to. On SkyPortal, if a user wants to see the data you poll from Fink, he should be in this group.
+The `whitelisted` field indicates if your IP address is whitelisted in SkyPortal. Indeed, SkyPortal's limits how many API calls can be in "queue" at once. If you are not whitelisted and make too many API calls at once, they will be skipped. Therefore, we added a delay of 1 second between alerts. But if you are whitelisted, you can set this to `true` to skip that delay.
 
 
 ## Running the Tests

--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -45,9 +45,11 @@ group_id: 'your_fink_group'
 servers: localhost:9093
 mytopics:
   ["test_stream"]
-testing: false
 skyportal_url: http://localhost:5000
 skyportal_token: 9d2530a0-a3dc-446b-9cf9-968736699e5a
+skyportal_group: 'group_name'
+testing: true
+whitelisted: false
 ```
 
 #### Fink credentials
@@ -73,3 +75,4 @@ This simple argument is a boolean that indicates whether you want to run the cli
 
 The `skyportal_url` and `skyportal_token` fields are used to connect to the SkyPortal instance. The url is simply the address of the SkyPortal instance, and the token is an api token that you can create and/or find in your SkyPortal's user profile.
 The `skyportal_group` field is the group that you want the alerts to belong to. On SkyPortal, if a user wants to see the data you poll from Fink, he should be in this group.
+The `whitelisted` field indicates if your IP address is whitelisted in SkyPortal. Indeed, SkyPortal's limits how many API calls can be in "queue" at once. If you are not whitelisted and make too many API calls at once, they will be skipped. Therefore, we added a delay of 1 second between alerts. But if you are whitelisted, you can set this to `true` to skip that delay.

--- a/skyportal_fink_client/skyportal_fink_client.py
+++ b/skyportal_fink_client/skyportal_fink_client.py
@@ -36,6 +36,8 @@ def poll_alerts(maxtimeout: int = 5):
         "group_id": conf["group_id"],
     }
 
+    whitelisted = conf["whitelisted"]
+
     if conf["password"] is not None:
         myconfig["password"] = conf["password"]
 
@@ -124,6 +126,7 @@ def poll_alerts(maxtimeout: int = 5):
                         filter_id,
                         stream_id,
                         taxonomy_id,
+                        whitelisted,
                         url=conf["skyportal_url"],
                         token=conf["skyportal_token"],
                     )

--- a/skyportal_fink_client/utils/skyportal_api.py
+++ b/skyportal_fink_client/utils/skyportal_api.py
@@ -1072,6 +1072,7 @@ def from_fink_to_skyportal(
     filter_id: int,
     stream_id: int,
     taxonomy_id: int,
+    whitelisted: bool,
     url: str,
     token: str,
 ):
@@ -1111,6 +1112,8 @@ def from_fink_to_skyportal(
             Id of the stream in skyportal that contains the alerts from fink (stream called fink_stream)
         taxonomy_id : int
             Id of the taxonomy in skyportal that contains the alerts from fink (taxonomy called Fink Taxonomy, but can also be omitted. If omitted, the classification will be searched in existing taxonomies)
+        whitelisted: bool
+            True if your IP is whitelisted in SkyPortal, False otherwise. This allows you to skip the delay of one second set in between alerts as SkyPortal limits API calls.
         url : str
             Skyportal url
         token : str
@@ -1120,7 +1123,8 @@ def from_fink_to_skyportal(
     ----------
         None
     """
-    time.sleep(1)
+    if not whitelisted:
+        time.sleep(1)
     overall_status = 200
     overall_status, skyportal_instruments = get_all_instruments(url=url, token=token)
     instrument_id = None

--- a/skyportal_fink_client/utils/skyportal_api.py
+++ b/skyportal_fink_client/utils/skyportal_api.py
@@ -928,7 +928,9 @@ def init_skyportal(group: str, url: str, token: str):
                 filter_id = filter["id"]
                 break
     if not filter_id:
-        filter_id = post_filters(f"{group.lower()}_filter", stream_id, group_id, url, token)[1]
+        filter_id = post_filters(
+            f"{group.lower()}_filter", stream_id, group_id, url, token
+        )[1]
 
     post_stream_access_to_group(stream_id, group_id, url, token)
 

--- a/tests/test_poll_alerts.py
+++ b/tests/test_poll_alerts.py
@@ -51,6 +51,9 @@ def test_poll_alerts():
     assert stream_id is not None
     assert filter_id is not None
 
+    whitelisted = conf["whitelisted"]
+    assert whitelisted is not None
+
     status, taxonomy_id = skyportal_api.get_fink_taxonomy_id(
         conf["skyportal_url"], conf["skyportal_token"]
     )
@@ -139,6 +142,7 @@ def test_poll_alerts():
                         filter_id,
                         stream_id,
                         taxonomy_id,
+                        whitelisted,
                         url=conf["skyportal_url"],
                         token=conf["skyportal_token"],
                     )

--- a/tests/test_poll_alerts.py
+++ b/tests/test_poll_alerts.py
@@ -54,7 +54,6 @@ def test_poll_alerts():
     status, taxonomy_id = skyportal_api.get_fink_taxonomy_id(
         conf["skyportal_url"], conf["skyportal_token"]
     )
-    assert taxonomy_id is not None
     if taxonomy_id is None:
         # post taxonomy
         # load taxonomy from data/taxonomy.yaml
@@ -76,6 +75,7 @@ def test_poll_alerts():
             print("Error while posting taxonomy")
             return
         print(f"Fink Taxonomy posted with id {taxonomy_id}")
+        assert taxonomy_id is not None
 
     failed_attempts = 0
     maxtimeout = 5

--- a/tests/test_skyportal_api.py
+++ b/tests/test_skyportal_api.py
@@ -342,6 +342,7 @@ def test_from_fink_to_skyportal():
         filter_id,
         stream_id,
         taxonomy_id,
+        False,
         "http://localhost:5000",
         skyportal_token,
     )


### PR DESCRIPTION
This PR adds a `whitelisted` boolean argument in the config, to specify if you are whitelisted by SkyPortal or not. If you are, you can skip the 1 second delay that we added between every alert. We added this delay as SkyPortal limits API calls made per second, and if ignored the alerts would be simply skipped by SkyPortal and nothing would be added. We strongly encourage a user to ask to be whitelisted if he expects a high number of alerts, and if he expects to receive all of them in real time.