### PR TITLE
Force Kilonova classification for given kn related topics

### DIFF
--- a/skyportal_fink_client/skyportal_fink_client.py
+++ b/skyportal_fink_client/skyportal_fink_client.py
@@ -224,7 +224,7 @@ def poll_alert(consumer: callable, maxtimeout: int, log: callable = None):
         return None, None
 
 
-def extract_alert_data(alert: dict = None):
+def extract_alert_data(topic: str = None, alert: dict = None):
 
     """
     Extracts the data from the alert.
@@ -252,7 +252,11 @@ def extract_alert_data(alert: dict = None):
         return None
     alert_pd = pd.DataFrame([alert])
     alert_pd["tracklet"] = ""
-    classification = extract_fink_classification_from_pdf(alert_pd)[0]
+    if topic in ["fink_kn_candidates_ztf", "fink_early_kn_candidates_ztf", "fink_rate_based_kn_candidates_ztf"]:
+        # we force the classification to a kilonova
+        classification = "Kilonova candidate"
+    else:                
+        classification = extract_fink_classification_from_pdf(alert_pd)[0]
     instruments = ["CFH12k", "ZTF"]
     magsys = "ab"
     object_id = alert["objectId"]
@@ -355,7 +359,7 @@ def poll_alerts(
     try:
         while True:
             topic, alert = poll_alert(consumer, maxtimeout, log)
-            data = extract_alert_data(alert)
+            data = extract_alert_data(topic, alert)
             if data is not None:
                 log(f"Received alert from topic {topic} with classification {data[-1]}")
                 skyportal_api.from_fink_to_skyportal(

--- a/skyportal_fink_client/skyportal_fink_client.py
+++ b/skyportal_fink_client/skyportal_fink_client.py
@@ -252,11 +252,18 @@ def extract_alert_data(topic: str = None, alert: dict = None):
         return None
     alert_pd = pd.DataFrame([alert])
     alert_pd["tracklet"] = ""
-    if topic in ["fink_kn_candidates_ztf", "fink_early_kn_candidates_ztf", "fink_rate_based_kn_candidates_ztf"]:
-        # we force the classification to a kilonova
+    classification = extract_fink_classification_from_pdf(alert_pd)[0]
+    # we force the classification to a kilonova for those topics
+    if (
+        topic
+        in [
+            "fink_kn_candidates_ztf",
+            "fink_early_kn_candidates_ztf",
+            "fink_rate_based_kn_candidates_ztf",
+        ]
+        and "kilonova" not in classification.lower()
+    ):
         classification = "Kilonova candidate"
-    else:                
-        classification = extract_fink_classification_from_pdf(alert_pd)[0]
     instruments = ["CFH12k", "ZTF"]
     magsys = "ab"
     object_id = alert["objectId"]

--- a/tests/test_skyportal_fink_client.py
+++ b/tests/test_skyportal_fink_client.py
@@ -168,7 +168,7 @@ def test_extract_alert_data():
     assert topic is not None
     assert alert is not None
     assert retries < max_retries
-    data = skyportal_fink_client.extract_alert_data(alert)
+    data = skyportal_fink_client.extract_alert_data(topic, alert)
     assert data is not None
 
 
@@ -228,7 +228,7 @@ def test_poll_alert_and_post_to_skyportal():
     assert topic is not None
     assert alert is not None
     assert retries < max_retries
-    data = skyportal_fink_client.extract_alert_data(alert)
+    data = skyportal_fink_client.extract_alert_data(topic, alert)
     assert data is not None
     status = skyportal_api.from_fink_to_skyportal(
         *data,


### PR DESCRIPTION
Right now, even if an alert ends passes some kilonova filters and end up being distributed in a kilonova topic, it's classification is not necessarily a kilonova. For example, a SN with a kn score high enough could end up in a kilonova topic, even though it has been classified as a SN.

This PR forces alerts from kilonova topics to be classified as kilonova in skyportal, to avoid confusion in production.