### PR TITLE
Fix issue with updating classifications

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -7,5 +7,6 @@ fink_servers: localhost:9093
 skyportal_token: 611c1ef7-77d7-467b-bfe8-b2f9730e3914 #this is a dummy token, replace with your own token, either from your profile, or from .tokens.yaml file in skyportal's directory
 skyportal_url: http://localhost:5000
 skyportal_group: Fink
+skyportal_name: provisioned-admin
 testing: true
 whitelisted: false

--- a/skyportal_fink_client/skyportal_fink_client.py
+++ b/skyportal_fink_client/skyportal_fink_client.py
@@ -116,8 +116,8 @@ def init_skyportal(
         taxonomy_id,
         skyportal_url,
         skyportal_token,
-        whitelisted,
         skyportal_name,
+        whitelisted,
     )
 
 
@@ -369,8 +369,8 @@ def poll_alerts(
         taxonomy_id,
         skyportal_url,
         skyportal_token,
-        whitelisted,
         skyportal_name,
+        whitelisted,
     ) = init_skyportal(
         skyportal_url,
         skyportal_token,

--- a/skyportal_fink_client/skyportal_fink_client.py
+++ b/skyportal_fink_client/skyportal_fink_client.py
@@ -30,6 +30,7 @@ def init_skyportal(
     skyportal_url: str = None,
     skyportal_token: str = None,
     skyportal_group: str = None,
+    skyportal_name: str = None,
     whitelisted: bool = None,
     log: callable = None,
 ):
@@ -65,6 +66,8 @@ def init_skyportal(
             Skyportal token
         whitelisted : bool
             If False, we take a 1 second pause between alerts
+        skyportal_name : str
+            Name of the user associated with the token in Skyportal
     """
     if skyportal_url is None:
         skyportal_url = conf["skyportal_url"]
@@ -77,6 +80,9 @@ def init_skyportal(
 
     if whitelisted is None:
         whitelisted = conf["whitelisted"]
+
+    if skyportal_name is None:
+        skyportal_name = conf["skyportal_name"]
 
     group_id, stream_id, filter_id = skyportal_api.init_skyportal_group(
         group=skyportal_group, url=skyportal_url, token=skyportal_token
@@ -111,6 +117,7 @@ def init_skyportal(
         skyportal_url,
         skyportal_token,
         whitelisted,
+        skyportal_name,
     )
 
 
@@ -304,6 +311,7 @@ def poll_alerts(
     skyportal_url: str = None,
     skyportal_token: str = None,
     skyportal_group: str = None,
+    skyportal_name: str = None,
     fink_username: str = None,
     fink_password: str = None,
     fink_group_id: str = None,
@@ -362,8 +370,14 @@ def poll_alerts(
         skyportal_url,
         skyportal_token,
         whitelisted,
+        skyportal_name,
     ) = init_skyportal(
-        skyportal_url, skyportal_token, skyportal_group, whitelisted, log
+        skyportal_url,
+        skyportal_token,
+        skyportal_group,
+        skyportal_name,
+        whitelisted,
+        log,
     )
     consumer = init_consumer(
         fink_username,
@@ -389,6 +403,7 @@ def poll_alerts(
                     whitelisted=whitelisted,
                     url=skyportal_url,
                     token=skyportal_token,
+                    skyportal_name=skyportal_name,
                     log=log,
                 )
 

--- a/skyportal_fink_client/utils/skyportal_api.py
+++ b/skyportal_fink_client/utils/skyportal_api.py
@@ -221,7 +221,7 @@ def get_all_stream_ids(url: str, token: str):
 
 
 def classification_exists_for_objs(
-    object_id: str, skyportal_name: str, url: str, token: str
+    object_id: str, skyportal_name: str, taxonomy_id: int, url: str, token: str
 ):
     """
     Check if a classification exists for a given object
@@ -230,6 +230,10 @@ def classification_exists_for_objs(
     ----------
         object_id : str
             Object id to check if classification exists for
+        skyportal_name : str
+            Skyportal name
+        taxonomy_id : int
+            Taxonomy id
         url : str
             Skyportal url
         token : str
@@ -256,46 +260,15 @@ def classification_exists_for_objs(
     classification_id = None
     author_id = None
     for classification in data:
-        if classification["author_name"] == skyportal_name:
+        if (
+            classification["author_name"] == skyportal_name
+            and classification["taxonomy_id"] == taxonomy_id
+        ):
             classification_id = classification["id"]
             author_id = classification["author_id"]
             break
 
     return classification_id, author_id
-
-
-def classification_id_for_objs(object_id: str, url: str, token: str):
-    """
-    Get classification id for a given object
-
-    Arguments
-    ----------
-        object_id : str
-            Object id to get classification id for
-        url : str
-            Skyportal url
-        token : str
-            Skyportal token
-
-    Returns
-    ----------
-        status_code : int
-            HTTP status code
-        data : list
-            List of classification ids and their author ids
-    """
-    classifications = api(
-        "GET",
-        f"{url}/api/sources/{object_id}/classifications",
-        token=token,
-    )
-    data = {}
-    if classifications.status_code == 200:
-        data = {
-            "id": classifications.json()["data"][0]["id"],
-            "author_id": classifications.json()["data"][0]["author_id"],
-        }
-    return classifications.status_code, data
 
 
 def post_source(
@@ -1212,7 +1185,7 @@ def from_fink_to_skyportal(
             )
         else:
             classification_id, author_id = classification_exists_for_objs(
-                object_id, skyportal_name, url=url, token=token
+                object_id, skyportal_name, taxonomy_id, url=url, token=token
             )
             log(f"Classification id: {classification_id}, author id: {author_id}")
             if classification_id is not None:

--- a/tests/test_skyportal_api.py
+++ b/tests/test_skyportal_api.py
@@ -69,7 +69,7 @@ def test_get_all_stream_ids():
 
 def test_classification_exists_for_objs():
     classification_id, author_id = skyportal_api.classification_exists_for_objs(
-        "ZTF18aabcvnq", skyportal_name, "http://localhost:5000", skyportal_token
+        "ZTF18aabcvnq", skyportal_name, 1, "http://localhost:5000", skyportal_token
     )
     assert classification_id is not None
     assert author_id is not None

--- a/tests/test_skyportal_api.py
+++ b/tests/test_skyportal_api.py
@@ -67,11 +67,11 @@ def test_get_all_stream_ids():
 
 
 def test_classification_exists_for_objs():
-    result = skyportal_api.classification_exists_for_objs(
+    classification_id, author_id = skyportal_api.classification_exists_for_objs(
         "ZTF18aabcvnq", "http://localhost:5000", skyportal_token
     )
-    assert result is not None
-    assert result == True
+    assert classification_id is not None
+    assert author_id is not None
 
 
 def test_classification_id_for_objs():

--- a/tests/test_skyportal_api.py
+++ b/tests/test_skyportal_api.py
@@ -8,6 +8,7 @@ conf = files.yaml_to_dict(
 )
 
 skyportal_token = conf["skyportal_token"]
+skyportal_name = conf["skyportal_name"]
 
 
 def test_get_all_groups_id():
@@ -68,18 +69,10 @@ def test_get_all_stream_ids():
 
 def test_classification_exists_for_objs():
     classification_id, author_id = skyportal_api.classification_exists_for_objs(
-        "ZTF18aabcvnq", "http://localhost:5000", skyportal_token
+        "ZTF18aabcvnq", skyportal_name, "http://localhost:5000", skyportal_token
     )
     assert classification_id is not None
     assert author_id is not None
-
-
-def test_classification_id_for_objs():
-    status, data = skyportal_api.classification_id_for_objs(
-        "ZTF18aabcvnq", "http://localhost:5000", skyportal_token
-    )
-    assert status == 200
-    assert data is not None
 
 
 def test_post_source():
@@ -377,6 +370,7 @@ def test_from_fink_to_skyportal():
         False,
         "http://localhost:5000",
         skyportal_token,
+        skyportal_name,
         log,
     )
 

--- a/tests/test_skyportal_api.py
+++ b/tests/test_skyportal_api.py
@@ -235,9 +235,12 @@ def test_post_taxonomy():
 
 def test_update_classification():
     status = skyportal_api.update_classification(
+        1,
+        1,
         "ZTF18aabcvnq",
         "kilonova",
         0.5,
+        "provisioned-admin",
         1,
         [1],
         "http://localhost:5000",

--- a/tests/test_skyportal_fink_client.py
+++ b/tests/test_skyportal_fink_client.py
@@ -17,6 +17,7 @@ schema = os.path.abspath(
 def init_test():
     skyportal_url = conf["skyportal_url"]
     skyportal_token = conf["skyportal_token"]
+    skyportal_name = conf["skyportal_name"]
     fink_username = conf["fink_username"]
     fink_password = conf["fink_password"]
     fink_group_id = conf["fink_group_id"]
@@ -27,6 +28,7 @@ def init_test():
     return (
         skyportal_url,
         skyportal_token,
+        skyportal_name,
         fink_username,
         fink_password,
         fink_group_id,
@@ -41,6 +43,7 @@ def test_init_skyportal():
     (
         skyportal_url,
         skyportal_token,
+        skyportal_name,
         fink_username,
         fink_password,
         fink_group_id,
@@ -58,9 +61,16 @@ def test_init_skyportal():
         taxonomy_id,
         skyportal_url,
         skyportal_token,
+        skyportal_group,
+        skyportal_name,
         whitelisted,
     ) = skyportal_fink_client.init_skyportal(
-        skyportal_url, skyportal_token, skyportal_group, whitelisted, log
+        skyportal_url,
+        skyportal_token,
+        skyportal_group,
+        skyportal_name,
+        whitelisted,
+        log,
     )
     assert group_id is not None
     assert stream_id is not None
@@ -176,6 +186,7 @@ def test_poll_alert_and_post_to_skyportal():
     (
         skyportal_url,
         skyportal_token,
+        skyportal_name,
         fink_username,
         fink_password,
         fink_group_id,
@@ -193,9 +204,15 @@ def test_poll_alert_and_post_to_skyportal():
         taxonomy_id,
         skyportal_url,
         skyportal_token,
+        skyportal_name,
         whitelisted,
     ) = skyportal_fink_client.init_skyportal(
-        skyportal_url, skyportal_token, skyportal_group, whitelisted, log
+        skyportal_url,
+        skyportal_token,
+        skyportal_group,
+        skyportal_name,
+        whitelisted,
+        log,
     )
     assert group_id is not None
     assert stream_id is not None

--- a/tests/test_skyportal_fink_client.py
+++ b/tests/test_skyportal_fink_client.py
@@ -220,6 +220,7 @@ def test_poll_alert_and_post_to_skyportal():
     assert taxonomy_id is not None
     assert skyportal_url is not None
     assert skyportal_token is not None
+    assert skyportal_name is not None
     assert whitelisted is not None
     consumer = skyportal_fink_client.init_consumer(
         fink_username,
@@ -256,6 +257,7 @@ def test_poll_alert_and_post_to_skyportal():
         whitelisted=whitelisted,
         url=skyportal_url,
         token=skyportal_token,
+        skyportal_name=skyportal_name,
         log=log
     )
 

--- a/tests/test_skyportal_fink_client.py
+++ b/tests/test_skyportal_fink_client.py
@@ -147,6 +147,7 @@ def test_extract_alert_data():
     (
         skyportal_url,
         skyportal_token,
+        skyportal_name,
         fink_username,
         fink_password,
         fink_group_id,

--- a/tests/test_skyportal_fink_client.py
+++ b/tests/test_skyportal_fink_client.py
@@ -61,7 +61,6 @@ def test_init_skyportal():
         taxonomy_id,
         skyportal_url,
         skyportal_token,
-        skyportal_group,
         skyportal_name,
         whitelisted,
     ) = skyportal_fink_client.init_skyportal(
@@ -78,6 +77,7 @@ def test_init_skyportal():
     assert taxonomy_id is not None
     assert skyportal_url is not None
     assert skyportal_token is not None
+    assert skyportal_name is not None
     assert whitelisted is not None
 
 

--- a/tests/test_skyportal_fink_client.py
+++ b/tests/test_skyportal_fink_client.py
@@ -85,6 +85,7 @@ def test_init_consumer():
     (
         skyportal_url,
         skyportal_token,
+        skyportal_name,
         fink_username,
         fink_password,
         fink_group_id,
@@ -110,6 +111,7 @@ def test_poll_alert():
     (
         skyportal_url,
         skyportal_token,
+        skyportal_name,
         fink_username,
         fink_password,
         fink_group_id,


### PR DESCRIPTION
Currently, if a source already has a classification, we update the first classification. However, what we want to do is update only the classification from skyportal-fink-client.

This PR addresses that issue.

